### PR TITLE
extend gradle config without chaning build.gradle

### DIFF
--- a/generators/app/templates/java-ee/build.gradle
+++ b/generators/app/templates/java-ee/build.gradle
@@ -43,13 +43,6 @@ wrapper {
 }
 */
 
-apply from: "$projectDir/gradle/ide.gradle"
-apply from: "$projectDir/gradle/clean.gradle"
-apply from: "$projectDir/gradle/repositories.gradle"
-apply from: "$projectDir/gradle/java.gradle"
-apply from: "$projectDir/gradle/junit.gradle"
-apply from: "$projectDir/gradle/jacoco.gradle"
-apply from: "$projectDir/gradle/findbugs.gradle"
-apply from: "$projectDir/gradle/docker-compose.gradle"
-apply from: "$projectDir/gradle/docs.gradle"
-//apply from: "$projectDir/gradle/build-scan.gradle"
+file("$projectDir/gradle/").eachFileMatch(~/.*\.gradle$/) {
+    apply from: it
+}


### PR DESCRIPTION
hello Maksim,

first of all thank you for sharing your project templates. 👍

the proposed change would allow you to extend your gradle configuration without changing `build.gradle` by just placing more `*.gradle` files in `/gradle`. it helps me start with a small initial configuration and add features as needed (f.e. with sub-generates)

best regards,
Yevgeniy